### PR TITLE
[network-proxy-setup] Permit !CONFIG_MODuLES

### DIFF
--- a/usr/lib/qubes-whonix/init/network-proxy-setup
+++ b/usr/lib/qubes-whonix/init/network-proxy-setup
@@ -30,10 +30,17 @@ if [ -e /var/run/qubes-service/whonix-gateway ]; then
     # Setup Xen / Qubes proxy
     network=$(qubesdb-read /qubes-netvm-network 2>/dev/null)
     if [ "x$network" != "x" ]; then
+
+        if [ -e /proc/sys/kernel ] && ! [ -e /proc/sys/kernel/modules_disabled ]; then
+	   readonly modprobe_fail_cmd='true'
+	else
+	   readonly modprobe_fail_cmd='false'
+	fi
+
         gateway=$(qubesdb-read /qubes-netvm-gateway)
         netmask=$(qubesdb-read /qubes-netvm-netmask)
         secondary_dns=$(qubesdb-read /qubes-netvm-secondary-dns)
-        modprobe netbk 2> /dev/null || modprobe xen-netback
+        modprobe netbk 2> /dev/null || modprobe xen-netback || "${modprobe_fail_cmd}"
         echo "NS1=$gateway" > /var/run/qubes/qubes-ns
         echo "NS2=$secondary_dns" >> /var/run/qubes/qubes-ns
         echo "0" > /proc/sys/net/ipv4/ip_forward


### PR DESCRIPTION
network-proxy-setup failure shuts down the machine on failure. This is a Very Good Thing, and I wouldn't aim to change that.

Currently it doesn't handle the case of CONFIG_MODULES=n though. This is my attempt at fixing that, and it's the simplest and least privileged method I could think of.

**However** my imagination is not sufficient to find all modes of failure, so I suggest pondering on the matter before accepting.

> * Check whether sysctl is accessible
> * Check whether a key which exists when CONFIG_MODULES=y is not accessible
>
> If true, CONFIG_MODULES=n, so ignore modprobe failure.
> If false, fail.