### PR TITLE
Possible fix for sudo in Whonix VMs

### DIFF
--- a/etc/sudoers.d/qubes-whonix
+++ b/etc/sudoers.d/qubes-whonix
@@ -3,3 +3,4 @@
 ## See the file COPYING for copying conditions.
 
 ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck *
+ALL ALL=NOPASSWD: /usr/sbin/virt-what *


### PR DESCRIPTION
This line can fix the problems faced in QubesOS/qubes-doc#176 for allowing dom0 prompt in Whonix based VMs. In particular, no dom0 prompts on startup and a unified guide for Debian/Whonix VMs.