### PR TITLE
Make qubes-whonix package compatible with Qubes 4.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,7 @@ Depends: qubes-core-agent (>= 2.1.60),
  rsync,
  whonix-gw-firewall | whonix-ws-firewall,
  curl,
+ qubes-core-agent (<< 4.0.0-1) | qubes-core-agent-networking,
  ${python:Depends},
  ${misc:Depends}
 Provides: ${diverted-files}
@@ -77,6 +78,7 @@ Depends: network-manager,
  tinyproxy,
  yum,
  yum-utils,
+ qubes-core-agent (<< 4.0.0-1) | qubes-core-agent-dom0-updates,
  ${misc:Depends}
 Description: Recommended packages for Qubes-Whonix-Gateway
  A metapackage, which installs packages, which are recommended for

--- a/usr/lib/qubes-whonix/init/network-proxy-setup
+++ b/usr/lib/qubes-whonix/init/network-proxy-setup
@@ -52,9 +52,10 @@ if [ "x$network" != "x" ]; then
 
     gateway=$(qubesdb-read /qubes-netvm-gateway)
     netmask=$(qubesdb-read /qubes-netvm-netmask)
+    primary_dns=$(qubesdb-read /qubes-netvm-primary-dns 2>/dev/null || echo $gateway)
     secondary_dns=$(qubesdb-read /qubes-netvm-secondary-dns)
     modprobe netbk 2> /dev/null || modprobe xen-netback || "${modprobe_fail_cmd}"
-    echo "NS1=$gateway" > /var/run/qubes/qubes-ns
+    echo "NS1=$primary_dns" > /var/run/qubes/qubes-ns
     echo "NS2=$secondary_dns" >> /var/run/qubes/qubes-ns
     echo "0" > /proc/sys/net/ipv4/ip_forward
     /sbin/ethtool -K eth0 sg off || true

--- a/usr/lib/qubes-whonix/utility_functions.sh
+++ b/usr/lib/qubes-whonix/utility_functions.sh
@@ -23,7 +23,11 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # 'apt-get' proxy server
-PROXY_SERVER='http://10.137.255.254:8082/'
+if systemctl -q is-active qubes-updates-proxy-forwarder.socket; then
+    PROXY_SERVER='http://127.0.0.1:8082/'
+else
+    PROXY_SERVER='http://10.137.255.254:8082/'
+fi
 
 # A magic line in the error pages tinyproxy (from qubes-updates-proxy) and
 # squid (qubes-updates-cache) send on Whonix when something connects to their


### PR DESCRIPTION
Those are changes required for Whonix to work on Qubes 4.0:
 - adjust for updates proxy - apt is configured correctly, but the script checking if the updates proxy is torified use wrong address (for qrexec-based proxy, you should connect to localhost)
 - adjust dependencies for split qubes-core-agent package

This should make the package compatible with both Qubes 3.2 and Qubes 4.0. After applying those changes, Whonix 13 templates looks to be working on Qubes 4.0 - tested via `whonixcheck` and working TorBrowser in anon-whonix.

As for packages - `qubes-core-agent-passwordless-root` is not installed there, meaning there is no unlimited access from user to root. Only selected commands, according to the configuration. To access root shell, one need to run `xterm` (or such) as root: `qvm-run -u root sys-whonix xterm`. This can be eased by installing `qubes-core-agent-passwordless-root`, similar to other packages. Do you have any preference?