### PR TITLE
Drop salt dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,7 @@ Description: Qubes Configuration for Whonix-Gateway and Whonix-Workstation
 Package: qubes-whonix-shared-packages-recommended
 Architecture: all
 Depends: qubes-core-agent-passwordless-root | dummy-dependency,
- qubes-kernel-vm-support, qubes-mgmt-salt-vm-connector,
+ qubes-kernel-vm-support,
  qubes-usb-proxy, qubes-input-proxy-sender,
  qubes-core-agent-thunar, qubes-core-agent-nautilus,
  ${misc:Depends}


### PR DESCRIPTION
It isn't available in bookworm

QubesOS/qubes-issues#7896